### PR TITLE
Remove body-parser

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,13 +1,11 @@
 const express = require('express');
 const app = express();
-const bodyParser = require('body-parser');
 const { request, response } = require('express');
 const port = 3000;
 
 app.set("view engine", "ejs");
 app.use(express.static("public"));
-app.use(bodyParser.urlencoded({ extended: true }));
-app.use(bodyParser.json());
+app.use(express.json());
 
 var id = 0;
 var TodoList = [];


### PR DESCRIPTION
Express 4.16+ has implemented its own version of body-parser so you do not need to add the dependency to your project.